### PR TITLE
mark color & reservation spacing

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -22,6 +22,8 @@ $border-radius:    13px;
 $border-radius-lg: 13px;
 $border-radius-sm: 13px;
 
+$mark-bg: $ow-green-5;
+
 // Override other variables below!
 .bg-light-green {
   background-color: $ow-green-4 !important;

--- a/app/views/cooking_sessions/show.html.erb
+++ b/app/views/cooking_sessions/show.html.erb
@@ -20,14 +20,18 @@
           <div class="card-body">
             <h5>Do you want some of <%= @cooking_session.chef.user.username %>'s <%= @cooking_session.meal.name %>?</h5>
             <%= simple_form_for [@cooking_session, @reservation] do |f| %>
-              <h6>It will be <strong>ready in <%=  distance_of_time_in_words_to_now(@cooking_session.end_at) %></strong> at <strong><%= @cooking_session.address %></strong></h6>
+              <h6>It will be <mark>ready in <%=  distance_of_time_in_words_to_now(@cooking_session.end_at) %></mark> at <strong><%= @cooking_session.address %></strong></h6>
               <h6>(<%= @cooking_session.distance_to(last_location.coordinates).round(1) %>km away from you)</h6>
               <br>
-              <div class="d-flex mx-3 p-1">
-                <%= f.input :portion_count, as: :radio_buttons, collection: 1..@cooking_session.portions_left, label: "Yes, please! Give me...", wrapper: :vertical_collection_inline %>
+              <div class="d-flex">
+                <%= f.input :portion_count, as: :radio_buttons,
+                collection: 1..@cooking_session.portions_left,
+                label: "Yes, please! Give me...",
+                legend_tag_html: { class: "float-none" },
+                wrapper: :vertical_collection_inline, class: "px-0" %>
                 <p class="align-self-end">portions.</p>
               </div>
-                <%= f.submit "Let's get Osusowake!", class: "btn btn-outline-success mb-2" %>
+                <%= f.submit "Let's Osusowake!", class: "btn btn-outline-success mb-2" %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
Closes #127 
Moved "positions" closer to radio button form
Caio suggested using mark (looks like green highlighter) instead of strong.  Let me know if you like it or not.

<img width="516" alt="Screen Shot 2022-03-23 at 2 48 06 PM" src="https://user-images.githubusercontent.com/92998577/159793585-ba2ba929-f30d-41eb-bca6-9d09a579a6ea.png">
