### PR TITLE
Descending order of CS on ChefTable

### DIFF
--- a/app/views/user/chefs/_cookbook_card.html.erb
+++ b/app/views/user/chefs/_cookbook_card.html.erb
@@ -1,5 +1,5 @@
 <% if chef.meals.exists? %>
-  <h3>Your Cookbook</h3>
+  <h3 class="mb-3">Your Cookbook</h3>
   <div class="row">
     <% chef.meals.each do |meal| %>
       <div class="col-sm-4 col-lg-2">

--- a/app/views/user/chefs/show.html.erb
+++ b/app/views/user/chefs/show.html.erb
@@ -1,14 +1,13 @@
-<div class="container d-flex justify-content-center">
-  <h1 class="mt-3 mb-3">Welcome <strong><%= @chef.user.username %>!</h1>
+<div class="container d-flex justify-content-center my-5">
+  <h1 class="mt-3 mb-3">Welcome back <strong><%= @chef.user.username %>!</h1>
 </div>
-<hr>
 <% if @chef.meals.present? %>
   <div class="container mb-3">
-    <h3>What's Cooking?</h3>
+    <h3 class="mb-3">What's Cooking?</h3>
     <div class="grid-lg-2">
       <% @chef.meals.each do |meal| %>
         <% if meal.cooking_sessions.exists? %>
-          <% meal.cooking_sessions.each do |cooking_session|%>
+          <% meal.cooking_sessions.upcoming.each do |cooking_session|%>
             <div class="card overflow-hidden">
               <div class="d-flex flex-grow-1">
                 <%= cl_image_tag meal.photo.key,  height:180, width:260, crop: :fill, class: "img-fluid object-fit-cover", style: "max-width: 130px" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -98,23 +98,23 @@ meals[0..3].each do |meal|
   )
 end
 
-meals[4..6].each do |meal|
-  chef = meal.chef
-  cooking_sessions << CookingSession.create!(
-    max_portions: rand(3..6),
-    address: chef.address,
-    longitude: chef.longitude,
-    latitude: chef.latitude,
-    start_at: Faker::Time.backward(days: 1, period: :afternoon, format: :long),
-    end_at: Faker::Time.backward(days: 1, period: :evening, format: :long),
-    meal: meal,
-    streaming: false
-  )
-end
+# meals[4..6].each do |meal|
+#   chef = meal.chef
+#   cooking_sessions << CookingSession.create!(
+#     max_portions: rand(3..6),
+#     address: chef.address,
+#     longitude: chef.longitude,
+#     latitude: chef.latitude,
+#     start_at: Faker::Time.backward(days: 1, period: :afternoon, format: :long),
+#     end_at: Faker::Time.backward(days: 1, period: :evening, format: :long),
+#     meal: meal,
+#     streaming: false
+#   )
+# end
 puts "---done---"
 
 puts "---creating fake near future cooking sessions---"
-meals[7..14].each do |meal|
+meals[4..11].each do |meal|
   chef = meal.chef
   cooking_sessions << CookingSession.create!(
     max_portions: rand(3..6),
@@ -130,7 +130,7 @@ end
 puts "---done---"
 
 puts "---creating fake future cooking sessions---"
-meals[15..19].each do |meal|
+meals[12..19].each do |meal|
   chef = meal.chef
   cooking_sessions << CookingSession.create!(
     max_portions: rand(3..6),


### PR DESCRIPTION
Descending order applied to Chef's Table CS.
Also removed some past CS from seeds as they were showing like "PickUp in 1 day" as if they were future CS. 

![localhost_3000_user_chef_(Caio)](https://user-images.githubusercontent.com/97905164/160170762-d58a7447-19df-4e20-8866-0558fd4fb7e3.png)
